### PR TITLE
feat: 🎸 add helper to call all callbacks

### DIFF
--- a/docs/callAllEventHandlers.mdx
+++ b/docs/callAllEventHandlers.mdx
@@ -1,0 +1,44 @@
+---
+name: callAllEventHandlers
+menu: Helpers
+---
+
+import { Playground } from 'docz';
+import { useHover, callAllEventHandlers } from '../src';
+
+# callAllEventHandlers
+
+Returns a function that will invoke all given functions with the its arguments.
+
+```js
+import { useHover, callAllEventHandlers } from 'use-events';
+```
+
+```jsx
+const Example = () => {
+  const [isHovered, bind] = useHover();
+
+  return (
+    <div
+      onMouseEnter={callAllEventHandlers(bind.onMouseEnter, console.log)}
+      onMouseLeave={callAllEventHandlers(bind.onMouseLeave, console.log)}
+    >
+      You are {isHovered ? 'hovering' : 'not hovering'} this div
+    </div>
+  );
+};
+```
+
+<Playground>
+  {() => {
+    const [isHovered, bind] = useHover();
+    return (
+      <div
+        onMouseEnter={callAllEventHandlers(bind.onMouseEnter, console.log)}
+        onMouseLeave={callAllEventHandlers(bind.onMouseLeave, console.log)}
+      >
+        You are {isHovered ? 'hovering' : 'not hovering'} this div
+      </div>
+    );
+  }}
+</Playground>

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,12 @@
+export function callAllEventHandlers<
+  T extends React.ReactEventHandler<any>,
+  E extends React.SyntheticEvent<any>
+>(...fns: T[]) {
+  return function callable(event: E) {
+    fns.forEach(fn => {
+      if (fn) {
+        fn(event);
+      }
+    });
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,5 @@ export { default as useMousePosition } from './useMousePosition/index';
 export { default as useResizeObserver } from './useResizeObserver/index';
 export { default as useTouch } from './useTouch/index';
 export { default as useWindowResize } from './useWindowResize/index';
+
+export { callAllEventHandlers } from './helpers';


### PR DESCRIPTION
Addresses https://github.com/sandiiarov/use-events/issues/113. I could use some help with the types. I am not sure what the best interface for this helper is. 😄 

### Usage
```jsx
import * as React from 'react';
import { useHover, callAllEventHandlers } from 'use-events';

const Example = () => {
  const [isHovered, bind] = useHover();

  return (
    <div
      onMouseEnter={callAllEventHandlers<
        React.MouseEventHandler<HTMLDivElement>,
        React.MouseEvent<HTMLDivElement>
      >(bind.onMouseEnter, console.log)}
      onMouseLeave={callAllEventHandlers<
        React.MouseEventHandler<HTMLDivElement>,
        React.MouseEvent<HTMLDivElement>
      >(bind.onMouseLeave, console.log)}
    >
      You are {isHovered ? 'hovering' : 'not hovering'} this div
    </div>
  );
};
```