### PR TITLE
Change TSC compile target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
     "jsx": "react",


### PR DESCRIPTION
Currently your ES bundle contains const statements.

Those statements prevent the lib from working out of the box on IE11.

Workaround is to tell webpack to transpile the lib, but this is more work on user side, you should rather just transpile those const before publishing